### PR TITLE
Correct "modern" misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ What is svelte?
 
 It is a lightweight modern JavaScript library (4.1KB minified) intended for use on projects where legacy browser support is not necessary.
 
-It uses mordern JavaScript (querySelectorAll, classList, matchesSelector) to help make it as lightweight as possible and therefore only works on the latest version of mordern browsers E.g. Chrome, Firefox, Opera, IE10+.
+It uses modern JavaScript (querySelectorAll, classList, matchesSelector) to help make it as lightweight as possible and therefore only works on the latest version of modern browsers E.g. Chrome, Firefox, Opera, IE10+.
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/svelte.svg)](https://saucelabs.com/u/svelte)
 


### PR DESCRIPTION
There were a couple of places where `modern` was misspelled as `mordern`.